### PR TITLE
Dirty fix for click handling on half-empty scrollable container

### DIFF
--- a/app/src/main/java/dreamers/graphics/TouchTracker.java
+++ b/app/src/main/java/dreamers/graphics/TouchTracker.java
@@ -39,7 +39,7 @@ public class TouchTracker implements View.OnTouchListener{
         if(v.isClickable() || v.isLongClickable()) {
             switch (event.getAction()) {
                 case MotionEvent.ACTION_UP:
-                    if (mPrePressed || v.isPressed()) {
+                    if ((mPrePressed && pointInView(v, x, y, mTouchSlop)) || v.isPressed()) {
                         // take focus if we don't have it already and we should in
                         // touch mode.
                         boolean focusTaken = false;


### PR DESCRIPTION
If you press an item of half-empty scrollable container (which is obliviously not scrollable now) and move your finger away out of the item's bounds and then release... view is being clicked. This is probably not perfect solution, but it solves the issue.