### PR TITLE
Add proguard rule so that ripple effect can work in release package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Usage
     
 ```
 
+Add following in proguard rules to ensure that ripple effect works in release package.
 
+    -keep class dreamers.graphics.** {*;}
 
 License
 --------

--- a/sample/proguard-rules.pro
+++ b/sample/proguard-rules.pro
@@ -15,3 +15,4 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+-keep class dreamers.graphics.** {*;}


### PR DESCRIPTION
As nineoldandroids ObjectAnimator uses reflection to access get/sets, we
need proguard rules to protect RippleDrawable.
