### PR TITLE
Fix NoSuchMethodError on super.getDirtyBounds()

### DIFF
--- a/app/src/main/java/codetail/graphics/drawables/LollipopDrawable.java
+++ b/app/src/main/java/codetail/graphics/drawables/LollipopDrawable.java
@@ -21,6 +21,20 @@ public abstract class LollipopDrawable extends Drawable {
     private ColorFilter mColorFilter;
 
     /**
+     * Return the drawable's dirty bounds Rect. Note: for efficiency, the
+     * returned object may be the same object stored in the drawable (though
+     * this is not guaranteed).
+     * <p>
+     * By default, this returns the full drawable bounds. Custom drawables may
+     * override this method to perform more precise invalidation.
+     *
+     * @return The dirty bounds of this drawable
+     */
+    public Rect getDirtyBounds() {
+        return getBounds();
+    }
+
+    /**
      * Inflate this Drawable from an XML resource optionally styled by a theme.
      *
      * @param r Resources used to resolve attribute values


### PR DESCRIPTION
RippleDrawable#getDirtyBounds() calls super.
It is API >= 21 method but is missing from LollipopDrawable.
This exception only happens on pre-lollipop Androids.
